### PR TITLE
[FEAT] 계약서 목록 조회 & 다운로드 API 구현

### DIFF
--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/controller/ContractQueryController.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/controller/ContractQueryController.java
@@ -5,10 +5,13 @@ import com.ddis.ddis_hr.employee.query.service.ContractQueryService;
 import com.ddis.ddis_hr.member.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/contracts")
@@ -21,14 +24,50 @@ public class ContractQueryController {
         this.contractQueryService = contractQueryService;
     }
 
-
-    // 내 계약서 전체 조회
+    /**
+     * 1) 내 계약서 목록 조회
+     *    - 호출 권한: 인증된 모든 사원 (ROLE_USER, ROLE_HR)
+     *    - 동작: 사용자는 자신의 계약서 목록만 조회 가능
+     *    - URL: GET /contracts/my
+     */
     @GetMapping("/my")
     public ResponseEntity<List<MyContractDTO>> getMyContracts(
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         Long empId = user.getEmployeeId();
-        List<MyContractDTO> contracts = contractQueryService.findByEmployeeId(empId);
-        return ResponseEntity.ok(contracts);
+        List<MyContractDTO> list = contractQueryService.findByEmployeeId(empId);
+        return ResponseEntity.ok(list);
+    }
+
+    /**
+     * 2) 인사팀 전체 계약서 목록 조회
+     *    - 호출 권한: ROLE_HR
+     *    - 동작: 인사팀은 전 사원의 계약서 목록을 조회 가능
+     *    - URL: GET /contracts
+     */
+    @PreAuthorize("hasRole('HR')")
+    @GetMapping
+    public ResponseEntity<List<MyContractDTO>> getAllContracts() {
+        List<MyContractDTO> list = contractQueryService.findAllContracts();
+        return ResponseEntity.ok(list);
+    }
+
+    /**
+     * 3) 계약서 다운로드 URL 발급
+     *    - 호출 권한: ROLE_USER, ROLE_HR
+     *    - 동작:
+     *        - 일반 사원(ROLE_USER)은 자신의 contractId만 다운로드 가능
+     *        - 인사팀(ROLE_HR)은 모든 사원의 contractId 다운로드 가능
+     *    - URL: GET /contracts/{contractId}/download
+     *    - 반환: { "url": "presigned-download-url" }
+     */
+    @PreAuthorize("hasAnyRole('USER','HR')")
+    @GetMapping("/{contractId}/download")
+    public ResponseEntity<Map<String, String>> downloadContract(
+            @PathVariable Long contractId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        String presignedUrl = contractQueryService.generateDownloadUrl(contractId, user);
+        return ResponseEntity.ok(Collections.singletonMap("url", presignedUrl));
     }
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dao/ContractMapper.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dao/ContractMapper.java
@@ -8,8 +8,12 @@ import java.util.List;
 
 @Mapper
 public interface ContractMapper {
-
-     // 로그인한 사원의 계약서 목록 조회
+    /** 본인 계약서 목록 */
     List<MyContractDTO> findByEmployeeId(@Param("employeeId") Long employeeId);
-}
 
+    /** 인사팀 전체 계약서 목록 */
+    List<MyContractDTO> findAllContracts();
+
+    /** 단일 계약서 조회 (메타·소유권 검사용) */
+    MyContractDTO findById(@Param("contractId") Long contractId);
+}

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dto/MyContractDTO.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dto/MyContractDTO.java
@@ -4,20 +4,17 @@ import lombok.*;
 
 import java.util.Date;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@Setter
-@ToString
+@Data
 public class MyContractDTO {
     private Long contractId;
     private String contractDescription;
-    private Date ContractReqDate;
-    private Date ContractDate;
-    private Date ContractEndDate;
-    private String ContractFileName;
-    private String ContractFileURL;
-    private Long ContractFileSize;
+    private Date contractReqDate;
+    private Date contractDate;
+    private Date contractEndDate;
+
+    private String contractFileName;
+    private String contractFileURL;     // 객체 키
+    private Long contractFileSize;
 
     private Long employeeId;
 

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/ContractQueryService.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/ContractQueryService.java
@@ -1,11 +1,26 @@
 package com.ddis.ddis_hr.employee.query.service;
 
 import com.ddis.ddis_hr.employee.query.dto.MyContractDTO;
+import com.ddis.ddis_hr.member.security.CustomUserDetails;
 
 import java.util.List;
 
 public interface ContractQueryService {
-
-    // 해당 사원 ID로 계약서 목록 조회
+    /** 본인 계약서 목록 조회 */
     List<MyContractDTO> findByEmployeeId(Long employeeId);
+
+    /** 인사팀 전체 계약서 목록 조회 */
+    List<MyContractDTO> findAllContracts();
+
+    /**
+     * 단일 계약서 권한 조회
+     *  - 일반 사원: 본인 소유만, 인사팀: 전체 가능
+     */
+    MyContractDTO findOne(Long contractId, CustomUserDetails user);
+
+    /**
+     * presigned URL 생성
+     *  - 내부에서 findOne 으로 권한·소유권 검사 후 URL 발급
+     */
+    String generateDownloadUrl(Long contractId, CustomUserDetails user);
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/ContractQueryServiceImpl.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/ContractQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.ddis.ddis_hr.employee.query.service;
 
-import com.ddis.ddis_hr.employee.query.dto.MyContractDTO;
 import com.ddis.ddis_hr.employee.query.dao.ContractMapper;
+import com.ddis.ddis_hr.employee.query.dao.DisciplinaryMapper;
+import com.ddis.ddis_hr.employee.query.dto.MyContractDTO;
 import com.ddis.ddis_hr.S3Config.service.S3Service;
+import com.ddis.ddis_hr.member.security.CustomUserDetails;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,14 +26,38 @@ public class ContractQueryServiceImpl implements ContractQueryService {
 
     @Override
     public List<MyContractDTO> findByEmployeeId(Long employeeId) {
-        List<MyContractDTO> list = contractMapper.findByEmployeeId(employeeId);
+        // 일반 사원·HR 모두 자신의 목록 조회 가능
+        return contractMapper.findByEmployeeId(employeeId);
+    }
 
-        // S3에서 다운로드용 presigned URL 생성
-        for (MyContractDTO dto : list) {
-            String key = dto.getContractFileURL();  // mapper에서 key(column)로 채워둔 값
-            String url = s3Service.generateDownloadUrl(key, null);
-            dto.setContractFileURL(url);
+    @Override
+    public List<MyContractDTO> findAllContracts() {
+        // 인사팀 전용: 모든 사원 계약서 반환
+        return contractMapper.findAllContracts();
+    }
+
+    @Override
+    public MyContractDTO findOne(Long contractId, CustomUserDetails user) {
+        // 1) 메타 조회
+        MyContractDTO dto = contractMapper.findById(contractId);
+        if (dto == null) {
+            throw new EntityNotFoundException("계약서를 찾을 수 없습니다. id=" + contractId);
         }
-        return list;
+        // 2) 권한 판정
+        boolean isHr = user.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_HR"));
+        // 3) 일반 사원은 본인 것만, HR은 전체 허용
+        if (!isHr && !dto.getEmployeeId().equals(user.getEmployeeId())) {
+            throw new SecurityException("권한이 없습니다. 이 계약서에 접근할 수 없습니다.");
+        }
+        return dto;
+    }
+
+    @Override
+    public String generateDownloadUrl(Long contractId, CustomUserDetails user) {
+        // findOne 내부에서 권한·소유권 검사
+        MyContractDTO dto = findOne(contractId, user);
+        // presigned URL 발급 (contentType 필요 시 지정)
+        return s3Service.generateDownloadUrl(dto.getContractFileURL(), null);
     }
 }


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 이 PR에서 작업한 내용을 간략히 설명해 주세요.
1. 계약서 목록 조회 API 구현
2. 계약서 다운로드 API 구현
3. Postman 테스트
4. 다운로드 정상 동작 테스트
5. Restful API 적용
 
## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #49 

## 💡 추가 설명 (Additional Info)
> 
1. 전 사원의 계약서 목록은 인사팀만 조회 가능하도록 합니다. @PreAuthorize("hasRole('HR')")
2. 계약서 다운로드 시, 인사팀은 전 사원, 일반사원은 본인의 것만 다운로드 가능하게 권한 설정 합니다.
3. 파일 저장 혹은 다운로드 시, DB에 객체의 실제 경로가 아닌, key값을 두고 presigned url을 통해 접근 가능하도록 설정합니다.  
4. 파일 다운로드 시, presigned url이 발급되며, 이 경로를 통해 파일을 다운로드 할 수 있습니다. (실제 경로 노출 X)

![사원_계약서목록_조회](https://github.com/user-attachments/assets/1609a021-621a-4775-a3bc-5b9a2b140bf4)
![사원_계약서_다운로드](https://github.com/user-attachments/assets/c6148609-4a03-4f9c-b98c-87f1fda23915)

https://github.com/user-attachments/assets/77281a7e-32fa-4a3f-ad8c-ba330ce55a07









