### PR TITLE
[FEAT] 징계 목록 조회 & 다운로드 API 구현

### DIFF
--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/controller/DisciplinaryQueryController.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/controller/DisciplinaryQueryController.java
@@ -5,32 +5,65 @@ import com.ddis.ddis_hr.employee.query.service.DisciplinaryQueryService;
 import com.ddis.ddis_hr.member.security.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/disciplinary")
 public class DisciplinaryQueryController {
 
-    private final DisciplinaryQueryService disciplinaryQueryService;
+    private final DisciplinaryQueryService service;
 
     @Autowired
-    public DisciplinaryQueryController(DisciplinaryQueryService disciplinaryQueryService) {
-        this.disciplinaryQueryService = disciplinaryQueryService;
+    public DisciplinaryQueryController(DisciplinaryQueryService service) {
+        this.service = service;
     }
 
-
-    // 내 징계 전체 조회
+    /**
+     * 1) 내 징계 목록 조회
+     *    - ROLE_USER, ROLE_HR 모두 호출 가능
+     *    - 본인 것만 반환
+     *    - GET /disciplinary/my
+     */
     @GetMapping("/my")
     public ResponseEntity<List<MyDisciplinaryDTO>> getMyDisciplinary(
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-        Long empId = user.getEmployeeId();
-        List<MyDisciplinaryDTO> disciplinary = disciplinaryQueryService.findByEmployeeId(empId);
-        return ResponseEntity.ok(disciplinary);
+        return ResponseEntity.ok(
+                service.findByEmployeeId(user.getEmployeeId())
+        );
+    }
+
+    /**
+     * 2) 인사팀 전체 징계 목록 조회
+     *    - ROLE_HR 전용
+     *    - GET /disciplinary
+     */
+    @PreAuthorize("hasRole('HR')")
+    @GetMapping
+    public ResponseEntity<List<MyDisciplinaryDTO>> getAllDisciplinary() {
+        return ResponseEntity.ok(
+                service.findAll()
+        );
+    }
+
+    /**
+     * 3) 징계 다운로드 URL 발급
+     *    - ROLE_USER: 본인 것만, ROLE_HR: 모든 징계 다운로드 가능
+     *    - GET /disciplinary/{id}/download
+     */
+    @PreAuthorize("hasAnyRole('USER','HR')")
+    @GetMapping("/{id}/download")
+    public ResponseEntity<Map<String,String>> download(
+            @PathVariable("id") Integer disciplinaryId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        String url = service.generateDownloadUrl(disciplinaryId, user);
+        return ResponseEntity.ok(Collections.singletonMap("url", url));
     }
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dao/DisciplinaryMapper.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/dao/DisciplinaryMapper.java
@@ -1,13 +1,18 @@
 package com.ddis.ddis_hr.employee.query.dao;
 
-import com.ddis.ddis_hr.employee.query.dto.MyContractDTO;
 import com.ddis.ddis_hr.employee.query.dto.MyDisciplinaryDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-
 import java.util.List;
 
 @Mapper
 public interface DisciplinaryMapper {
+    /** 본인 징계 목록 */
     List<MyDisciplinaryDTO> findByEmployeeId(@Param("employeeId") Long employeeId);
+
+    /** 인사팀 전체 징계 목록 */
+    List<MyDisciplinaryDTO> findAll();
+
+    /** 단일 징계 조회 (메타·소유권 검사용) */
+    MyDisciplinaryDTO findById(@Param("disciplinaryId") Integer disciplinaryId);
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/DisciplinaryQueryService.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/DisciplinaryQueryService.java
@@ -1,10 +1,26 @@
 package com.ddis.ddis_hr.employee.query.service;
 
-
 import com.ddis.ddis_hr.employee.query.dto.MyDisciplinaryDTO;
+import com.ddis.ddis_hr.member.security.CustomUserDetails;
 
 import java.util.List;
 
 public interface DisciplinaryQueryService {
+    /** 본인 징계 목록 조회 */
     List<MyDisciplinaryDTO> findByEmployeeId(Long employeeId);
+
+    /** 인사팀 전체 징계 목록 조회 */
+    List<MyDisciplinaryDTO> findAll();
+
+    /**
+     * 단일 징계 메타 조회
+     *  - 일반 사원: 본인 소유만, 인사팀: 전체 가능
+     */
+    MyDisciplinaryDTO findOne(Integer disciplinaryId, CustomUserDetails user);
+
+    /**
+     * presigned URL 생성
+     *  - 내부에서 findOne 으로 권한·소유권 검사 후 URL 발급
+     */
+    String generateDownloadUrl(Integer disciplinaryId, CustomUserDetails user);
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/DisciplinaryQueryServiceImpl.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/employee/query/service/DisciplinaryQueryServiceImpl.java
@@ -1,8 +1,10 @@
 package com.ddis.ddis_hr.employee.query.service;
 
-import com.ddis.ddis_hr.S3Config.service.S3Service;
 import com.ddis.ddis_hr.employee.query.dao.DisciplinaryMapper;
 import com.ddis.ddis_hr.employee.query.dto.MyDisciplinaryDTO;
+import com.ddis.ddis_hr.member.security.CustomUserDetails;
+import com.ddis.ddis_hr.S3Config.service.S3Service;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,28 +13,44 @@ import java.util.List;
 @Service
 public class DisciplinaryQueryServiceImpl implements DisciplinaryQueryService {
 
-    private final DisciplinaryMapper disciplinaryMapper;
-    private final S3Service s3Service;
+    private final DisciplinaryMapper mapper;
+    private final S3Service         s3Service;
 
     @Autowired
-    public DisciplinaryQueryServiceImpl(DisciplinaryMapper disciplinaryMapper,
+    public DisciplinaryQueryServiceImpl(DisciplinaryMapper mapper,
                                         S3Service s3Service) {
-        this.disciplinaryMapper = disciplinaryMapper;
+        this.mapper   = mapper;
         this.s3Service = s3Service;
     }
 
     @Override
     public List<MyDisciplinaryDTO> findByEmployeeId(Long employeeId) {
-        List<MyDisciplinaryDTO> list = disciplinaryMapper.findByEmployeeId(employeeId);
+        return mapper.findByEmployeeId(employeeId);
+    }
 
-        // S3에서 다운로드용 presigned URL 생성
-        for (MyDisciplinaryDTO dto : list) {
-            String key = dto.getDisciplinaryFilePath();  // mapper에서 key(column)로 채워둔 값
-            String url = s3Service.generateDownloadUrl(key, null);
-            dto.setDisciplinaryFilePath(url);
+    @Override
+    public List<MyDisciplinaryDTO> findAll() {
+        return mapper.findAll();
+    }
+
+    @Override
+    public MyDisciplinaryDTO findOne(Integer disciplinaryId, CustomUserDetails user) {
+        MyDisciplinaryDTO dto = mapper.findById(disciplinaryId);
+        if (dto == null) {
+            throw new EntityNotFoundException("해당 징계 기록을 찾을 수 없습니다. id=" + disciplinaryId);
         }
-        return list;
+        boolean isHr = user.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_HR"));
+        if (!isHr && !dto.getEmployeeId().equals(user.getEmployeeId())) {
+            throw new SecurityException("권한이 없습니다. 이 징계 기록에 접근할 수 없습니다.");
+        }
+        return dto;
+    }
+
+    @Override
+    public String generateDownloadUrl(Integer disciplinaryId, CustomUserDetails user) {
+        MyDisciplinaryDTO dto = findOne(disciplinaryId, user);
+        // presigned URL 생성 (dto.getDisciplinaryFileKey()가 S3 key)
+        return s3Service.generateDownloadUrl(dto.getDisciplinaryFilePath(), null);
     }
 }
-
-


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 이 PR에서 작업한 내용을 간략히 설명해 주세요.
1. 계약서 목록 조회 API 구현
2. 계약서 다운로드 API 구현
3. Postman 테스트
4. 다운로드 정상 동작 테스트
5. Restful API 적용
 
## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- close #54 

## 💡 추가 설명 (Additional Info)
> 
1. 전 사원의 징계 목록은 인사팀만 조회 가능하도록 합니다. @PreAuthorize("hasRole('HR')")
2. 징계문서 다운로드 시, 인사팀은 전 사원, 일반사원은 본인의 것만 다운로드 가능하게 권한 설정 합니다.
3. 파일 저장 혹은 다운로드 시, DB에 객체의 실제 경로가 아닌, key값을 두고 presigned url을 통해 접근 가능하도록 설정합니다.  
4. 파일 다운로드 시, presigned url이 발급되며, 이 경로를 통해 파일을 다운로드 할 수 있습니다. (실제 경로 노출 X)

![사원_징계목록_조회](https://github.com/user-attachments/assets/c179521a-5c7e-4f72-92b2-c18e5bd5a7e6)
![사원_징계문서_다운로드](https://github.com/user-attachments/assets/0df1a3ee-6e12-4143-8190-b9121db5f927)

https://github.com/user-attachments/assets/7b1f22ac-3cdc-4f6e-a160-2dfeab9836a0


