### PR TITLE
[REFACTOR] 결재라인조회 , 기안자 정보조회토큰 활용 코드 수정

### DIFF
--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/controller/ApprovalLineQueryController.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/controller/ApprovalLineQueryController.java
@@ -36,7 +36,7 @@ public class ApprovalLineQueryController {
     @GetMapping
     public ResponseEntity<List<ApproverQueryDTO>> getApprovalLine(Authentication authentication) {
         // 인증 컨텍스트에서 사용자 사번(subject) 획득
-        String employeeId = authentication.getName();
+        Long employeeId = Long.valueOf(authentication.getName());
 
         // 서비스 호출: 결재라인 생성
         List<ApproverQueryDTO> line = approvalLineQueryService.generateApprovalLine(employeeId);

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/controller/DrafterQueryController.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/controller/DrafterQueryController.java
@@ -2,12 +2,16 @@ package com.ddis.ddis_hr.eapproval.query.controller;
 
 import com.ddis.ddis_hr.eapproval.query.dto.FindDrafterQueryDTO;
 import com.ddis.ddis_hr.eapproval.query.service.DrafterQueryService;
+import com.ddis.ddis_hr.member.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,9 +21,11 @@ public class DrafterQueryController {
     private final DrafterQueryService userService;
 
     @GetMapping("/me")
-    public ResponseEntity<FindDrafterQueryDTO> getMyInfo(@RequestHeader("Authorization") String token) {
-        FindDrafterQueryDTO userInfo = userService.getfindDrafterInfo(token);
-        System.out.println("💡 userInfo: " + userInfo); // 혹은 log.info()
+    public ResponseEntity<FindDrafterQueryDTO> getMyInfo(@AuthenticationPrincipal CustomUserDetails user) {
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증된 사용자 정보가 없습니다.");
+        }
+        FindDrafterQueryDTO userInfo = userService.getfindDrafterInfo(user.getEmployeeId());
         return ResponseEntity.ok(userInfo);
     }
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/dto/FindDrafterQueryDTO.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/dto/FindDrafterQueryDTO.java
@@ -17,7 +17,7 @@ import lombok.*;
  */
 public class FindDrafterQueryDTO {
     /** 로그인한 사용자의 사번(empId) */
-    private String empId;
+    private Long empId;
 
     /** 로그인한 사용자의 이름 */
     private String name;

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/mapper/DraftMapper.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/mapper/DraftMapper.java
@@ -1,9 +1,10 @@
 package com.ddis.ddis_hr.eapproval.query.mapper;
 
+import com.ddis.ddis_hr.eapproval.query.dto.ApprovalStepQueryDTO;
 import com.ddis.ddis_hr.eapproval.query.dto.ApprovalLineQueryDTO;
 import com.ddis.ddis_hr.eapproval.query.dto.ContentQueryDTO;
 import com.ddis.ddis_hr.eapproval.query.dto.DraftDetailResponseQueryDTO;
-import com.ddis.ddis_hr.eapproval.query.dto.FileDTO;
+import com.ddis.ddis_hr.eapproval.query.dto.FileQueryDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -15,9 +16,9 @@ public interface DraftMapper {
         DraftDetailResponseQueryDTO selectDraftDetail(@Param("docId") Long docId);
         List<ApprovalLineQueryDTO> selectApprovalLines(int docId);
         ContentQueryDTO selectContent(int docId);
-        List<FileDTO> selectFiles(int docId);
+        List<FileQueryDTO> selectFiles(int docId);
 
-        String test();
+        List<ApprovalStepQueryDTO> findApprovalStepsByPosition(String position);
 
 
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/mapper/FindDrafterMapper.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/mapper/FindDrafterMapper.java
@@ -7,7 +7,7 @@ import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface FindDrafterMapper {
-        FindDrafterQueryDTO findDrafterInfo(String empId);
+        FindDrafterQueryDTO findDrafterInfo(Long empId);
 
         ApproverInfoQueryDTO findApproverByTeamAndPosition(@Param("teamId") Long teamId,
                                                            @Param("positionName") String positionName);

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/ApprovalLineQueryService.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/ApprovalLineQueryService.java
@@ -19,5 +19,5 @@ public interface ApprovalLineQueryService {
      * @param employeeId 로그인한 사용자의 사번 (또는 토큰 subject)
      * @return 단계별 실제 결재자 정보를 담은 ApproverDTO 리스트
      */
-    List<ApproverQueryDTO> generateApprovalLine(String employeeId);
+    List<ApproverQueryDTO> generateApprovalLine(Long employeeId);
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/ApprovalLineQueryServiceImpl.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/ApprovalLineQueryServiceImpl.java
@@ -57,7 +57,7 @@ public class ApprovalLineQueryServiceImpl implements ApprovalLineQueryService {
      * @return 단계별 결재자 정보 리스트
      */
     @Override
-    public List<ApproverQueryDTO> generateApprovalLine(String employeeId) {
+    public List<ApproverQueryDTO> generateApprovalLine(Long employeeId) {
         // 1) DrafterInfoDTO로부터 기안자 조직정보 획득
         FindDrafterQueryDTO drafter = drafterMapper.findDrafterInfo(employeeId);
 

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/DrafterQueryService.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/DrafterQueryService.java
@@ -3,6 +3,6 @@ package com.ddis.ddis_hr.eapproval.query.service;
 import com.ddis.ddis_hr.eapproval.query.dto.FindDrafterQueryDTO;
 
 public interface DrafterQueryService {
-    FindDrafterQueryDTO getfindDrafterInfo(String token);
+    FindDrafterQueryDTO getfindDrafterInfo(Long employeeId);
 
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/DrafterQueryServiceImpl.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/eapproval/query/service/DrafterQueryServiceImpl.java
@@ -10,13 +10,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DrafterQueryServiceImpl implements DrafterQueryService {
 
-    private final JwtUtil jwtUtil;
     private final FindDrafterMapper findDrafterMapper;
 
     @Override
-    public FindDrafterQueryDTO getfindDrafterInfo(String token) {
-        String empId = jwtUtil.getEmpIdFromToken(token);
-        return findDrafterMapper.findDrafterInfo(empId);
+    public FindDrafterQueryDTO getfindDrafterInfo(Long employeeId) {
+        return findDrafterMapper.findDrafterInfo(employeeId);
     }
 
 }

--- a/DDIS_HR/src/main/java/com/ddis/ddis_hr/member/security/JwtUtil.java
+++ b/DDIS_HR/src/main/java/com/ddis/ddis_hr/member/security/JwtUtil.java
@@ -77,12 +77,5 @@ public class JwtUtil {
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
-
-    public String getEmpIdFromToken(String token) {
-        if (token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
-        return parseClaims(token).getSubject();
-    }
     
 }

--- a/DDIS_HR/src/main/resources/com/ddis/ddis_hr/eapproval/query/mapper/FindDrafterMapper.xml
+++ b/DDIS_HR/src/main/resources/com/ddis/ddis_hr/eapproval/query/mapper/FindDrafterMapper.xml
@@ -21,7 +21,7 @@
 
     <!-- 2) 실제 SELECT: 컬럼에 alias를 DTO 프로퍼티명과 맞추고, resultMap 사용 -->
     <select id="findDrafterInfo"
-            parameterType="string"
+            parameterType="Long"
             resultMap="DrafterMap">
         SELECT
             e.employee_id     AS empId,


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 이 PR에서 작업한 내용을 간략히 설명해 주세요.
1.  결재라인조회 , 기안자 정보조회토큰 활용 코드 수정
 
## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- #74 

## 💡 추가 설명 (Additional Info)
> 수정 후 api테스트 캡쳐본 첨부
- 기안자 데이터 조회 api
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/2eab2b9c-bf08-4c40-8ee9-bc58e081be5e" />

- 직책 별 결재라인 조회api
<img width="1009" alt="스크린샷 2025-06-11 오후 1 14 52" src="https://github.com/user-attachments/assets/9ea76b0c-aa1b-474c-a270-f1ef18def009" />

- 실제 결재자 자동매칭 api
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/1d4a21c3-e2bf-44bb-a48b-bfbf66f98359" />


